### PR TITLE
Updated name of `verify-deploy.yml` to `ci-cd.yml`

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,7 +14,7 @@
 #     You should have received a copy of the GNU Affero General Public License
 #     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-name: Verify and Deploy
+name: CI/CD Pipeline
 on:
   pull_request:
     branches: [ main ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@
 #     You should have received a copy of the GNU Affero General Public License
 #     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-name: CI/CD Pipeline
+name: CI Pipeline
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
We aren't deploying anything, and it _is_ a CI/CD pipeline, so it should logically be `ci-cd.yml` instead of `verify-deploy.yml`.