### PR TITLE
Removed SPDX identifier from `gradle-wrapper.properties` per the advi…

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: AGPL-3.0-or-later
-# Copyright (c) robotsnh and project contributors
-
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip


### PR DESCRIPTION
…ce of @coderabbitai

We don't own this file, so it's therefore Apache 2.0.