### PR TITLE
chore: replaced AGPL boilerplate with AGPL SPDX identifiers in the CI …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,5 @@
-#     <A Github Actions workflow that verifies the build and automatically merges pull requests to main if the build is successful and is pushed by the repository owner.>
-#     Copyright (C) <2026> <@robotsnh>
-
-#     This program is free software: you can redistribute it and/or modify
-#     it under the terms of the GNU Affero General Public License as published
-#     by the Free Software Foundation, either version 3 of the License, or
-#     (at your option) any later version.
-
-#     This program is distributed in the hope that it will be useful,
-#     but WITHOUT ANY WARRANTY; without even the implied warranty of
-#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#     GNU Affero General Public License for more details.
-
-#     You should have received a copy of the GNU Affero General Public License
-#     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) robotsnh and project contributors
 
 name: CI Pipeline
 on:


### PR DESCRIPTION
…pipeline

This is necessary for brevity and consistency. In addition, SPDX identifiers are far more readable by automated scripts. In addition to this change, I've added a newline at the bottom of the file to comply with POSIX standards.