### PR TITLE
chore: added SPDX identifiers to the `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) robotsnh and project contributors
+
 * @robotsnh


### PR DESCRIPTION
This is necessary so it is easy for people to see which license our project has just by glancing at a file and easier for parsers and bots to read.