### PR TITLE
chore: run CI pipeline on pushes to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ name: CI Pipeline
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This commit modifies a section of the CI pipeline to run on pushes to `main`, not only PRs. This allows people to more easily download the latest build instead of having to search for the latest release or PR.